### PR TITLE
Remove RIF SMAC attribute from HLD

### DIFF
--- a/documentation/general/dash-sonic-hld.md
+++ b/documentation/general/dash-sonic-hld.md
@@ -559,7 +559,6 @@ SONiC for DASH shall have a lite swss initialization without the heavy-lift of e
 |                          | SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE  |  
 |                          | SAI_ROUTER_INTERFACE_ATTR_MTU  |
 |                          | SAI_ROUTER_INTERFACE_ATTR_PORT_ID  |
-|                          | SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS |
 |                          | SAI_ROUTER_INTERFACE_ATTR_TYPE  |  
 |                          | SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID  |  
 | Route                    | SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID  |  


### PR DESCRIPTION
Based on BMv2 discussion, the SRC mac of egress packet should be set based on SMAC of switch, not RIF. So, looks like this RIF SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS attribute is redundant in the doc, thus removing it. The SAI_SWITCH_ATTR_SRC_MAC_ADDRESS should used instead.